### PR TITLE
Added detail to type 3

### DIFF
--- a/Click-Types.md
+++ b/Click-Types.md
@@ -1,6 +1,6 @@
 **ID**|**Click Type**
 :-----|:-----
 1|Item can be cast from any slot.
-3|Item can be cast from any slot.
+3|Item can be cast from any slot (Expendable).
 4|Item must be equipped to cast effect.
 5|Seems to involve poisoning a weapon.


### PR DESCRIPTION
Also, Per Live intent (if not implementation) the Ghostly Bridle should not be expendable.  The quest test tells you to use the bridle to get to your quest guy, and the guest guy accepts the bridle for a recharge (but gives you a new item that will not recharge).  Currently, the bridle is expendable, and hence cant be turned in if you follow instructions.

Up to you guys if you want that on peq.  This is just a doc addition.